### PR TITLE
refactor: resolve plugins directly from the app container

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,6 @@
+const {
+    app
+} = require('@arkecosystem/core-container')
 const axios = require('axios')
 
 const handlers = require('./handlers')
@@ -10,23 +13,15 @@ const VALID_EVENTS = [
     'wallet.vote', 'wallet.unvote'
 ]
 
-class App {
-    constructor () {
+module.exports = class App {
+    constructor() {
         this.events = {}
-        this.emmiter = undefined
-        this.logger = undefined
+        this.emitter = app.resolvePlugin('event-emitter')
+        this.logger = app.resolvePlugin('logger')
     }
 
-    listen (container, options) {
-        this.emitter = container.resolvePlugin('event-emitter')
-        this.logger = container.resolvePlugin('logger')
-
-        this.setUp(options.webhooks)
-        Object.keys(this.events).map(event => this.subscribe(event))
-    }
-
-    setUp (webhooks) {
-        for (const webhook of webhooks) {
+    listen(options) {
+        for (const webhook of options.webhooks) {
             for (const event of webhook.events) {
                 if (!VALID_EVENTS.includes(event)) {
                     this.logger.warning(`${event} is not a valid event. Check events in your deadlock-notifier configuration`)
@@ -43,9 +38,11 @@ class App {
                 })
             }
         }
+
+        Object.keys(this.events).forEach(event => this.subscribe(event))
     }
 
-    subscribe (event) {
+    subscribe(event) {
         const context = {
             event,
             events: this.events,
@@ -54,7 +51,7 @@ class App {
             logger: this.logger
         }
 
-        this.emitter.on(event, async function (data) {
+        this.emitter.on(event, async data => {
             let payload = {}
             const webhooks = this.events[this.event]
             const messageData = await handlers[this.event](data)
@@ -72,11 +69,11 @@ class App {
         }, context)
     }
 
-    getMessage (platform, event, data) {
+    getMessage(platform, event, data) {
         return messages[platform][event](...data)
     }
 
-    detectPlatform (endpoint) {
+    detectPlatform(endpoint) {
         if (endpoint.includes('hooks.slack.com')) {
             return 'slack'
         } else if (endpoint.includes('discordapp.com')) {
@@ -86,5 +83,3 @@ class App {
         }
     }
 }
-
-module.exports = new App()

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-const app = require('./app.js')
+const App = require('./app')
 const defaults = require('./defaults')
 
 /**
@@ -20,12 +20,13 @@ exports.plugin = {
     pkg: require('../package.json'),
     defaults,
     alias: 'deadlock:notifier',
-    async register (container, options) {
+    async register(container, options) {
         if (!options.enabled) {
             return
         }
-        const logger = container.resolvePlugin('logger')
-        app.listen(container, options)
-        logger.debug('[Notifier] Up and running :mega:')
+
+        new App().listen(options)
+
+        container.resolvePlugin('logger').debug('[Notifier] Up and running :mega:')
     }
 }


### PR DESCRIPTION
The `module.exports = new App()` at the bottom of the `app.js` files means that the app object will exist before the container has anything registered.

Exporting instances that rely on the container before the container exists should be avoided.